### PR TITLE
Add Node test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+    - run: npm ci
+    - run: npm test

--- a/actual-mortgage-interest.ts
+++ b/actual-mortgage-interest.ts
@@ -4,6 +4,7 @@
 
 import "dotenv/config";
 import { format, parseISO, addMonths, isAfter, endOfMonth } from "date-fns";
+import { fileURLToPath } from "url";
 import {
     init,
     downloadBudget,
@@ -143,7 +144,7 @@ async function hasPostedInterest(transactions: Transaction[], importedId: string
 }
 
 /** Calculate booking and as-of dates for a given month cursor */
-function calculateBookingDates(cursor: Date, bookingDay: number): BookingDates {
+export function calculateBookingDates(cursor: Date, bookingDay: number): BookingDates {
     const lastDay = endOfMonth(cursor).getDate();
     const bookingDayAdjusted = Math.min(bookingDay, lastDay);
     const bookDate = new Date(cursor.getFullYear(), cursor.getMonth(), bookingDayAdjusted);
@@ -277,8 +278,10 @@ export async function main() {
     await service.run();
 }
 
-main().catch(err => {
-    console.error(err);
-    process.exit(1);
-});
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main().catch(err => {
+        console.error(err);
+        process.exit(1);
+    });
+}
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "scripts": {
     "run": "ts-node actual-mortgage-interest.ts",
-    "lint": "eslint --ext .ts . --fix"
+    "lint": "eslint --ext .ts . --fix",
+    "test": "node --loader ts-node/esm --test test/*.test.ts"
   },
   "type": "module",
   "devDependencies": {

--- a/test/actual-mortgage-interest.test.ts
+++ b/test/actual-mortgage-interest.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { parseISO } from "date-fns";
+
+import { calculateMonthlyInterest, calculateBookingDates } from "../actual-mortgage-interest.js";
+
+test("calculateMonthlyInterest computes monthly interest", () => {
+  const interest = calculateMonthlyInterest(100_000, 0.12); // 12% annual rate
+  const expected = Math.round(100_000 * (0.12 / 365 * 30));
+  assert.equal(interest, expected);
+});
+
+test("calculateBookingDates returns correct dates", () => {
+  const cursor = parseISO("2024-05-01");
+  const { bookDate, asOfDate } = calculateBookingDates(cursor, 25);
+  assert.equal(bookDate.toISOString().slice(0, 10), "2024-05-25");
+  assert.equal(asOfDate.toISOString().slice(0, 10), "2024-04-30");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- add tsconfig for ESM compilation
- expose `calculateBookingDates` and make main script import-safe
- add simple Node tests for interest calculation and booking dates
- wire up CI workflow to run tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687668d2ce64832eb2efeb6ea4d61bd5