### PR TITLE
Fix Jest moduleNameMapper config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ export default {
   preset: 'ts-jest/presets/default-esm',
   testEnvironment: 'node',
   extensionsToTreatAsEsm: ['.ts'],
-  moduleNameMapping: {
+  moduleNameMapper: {
     '^(\\.{1,2}/.*)\\.js$': '$1'
   },
   testMatch: [


### PR DESCRIPTION
## Summary
- use `moduleNameMapper` in Jest config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877526204a0832eab6d722aa1d4a96f