### PR TITLE
Add lint workflow and Taskfile

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,18 @@
+name: Lint
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm install
+      - run: npm run lint

--- a/README.md
+++ b/README.md
@@ -99,3 +99,11 @@ This script interacts directly with your Actual Budget data. While it includes a
 -   Test thoroughly with `DRY_RUN=true`.
 -   Review the transactions and budget amounts created by the script.
 
+## Development
+
+This repository provides a `Taskfile.yml` with a few convenience commands powered by [Taskfile](https://taskfile.dev/):
+
+- `task lint` – run ESLint with auto-fix
+- `task test` – execute the Jest test suite
+- `task run`  – run the mortgage interest script
+

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,12 @@
+version: '3'
+
+tasks:
+  lint:
+    cmds:
+      - npm run lint
+  test:
+    cmds:
+      - npm test
+  run:
+    cmds:
+      - npm run run


### PR DESCRIPTION
## Summary
- automate linting via GitHub Actions
- provide Taskfile commands
- document new development tasks in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68775298d820832ebebd52cfcaf4efe2