### PR TITLE
Add Prettier-ESLint integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,11 @@ This script interacts directly with your Actual Budget data. While it includes a
 
 This repository provides a `Taskfile.yml` with a few convenience commands powered by [Taskfile](https://taskfile.dev/):
 
-- `task lint` – run ESLint with auto-fix
-- `task test` – execute the Jest test suite
-- `task run`  – run the mortgage interest script
+- `task`        – list all available commands
+- `task lint`   – run ESLint with auto-fix
+- `task format` – run Prettier to format the codebase
+- `task test`   – execute the Jest test suite
+- `task run`    – run the mortgage interest script
+
+ESLint uses [`eslint-config-prettier`](https://github.com/prettier/eslint-config-prettier) to disable rules that conflict with Prettier's formatting.
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,9 +1,18 @@
 version: '3'
 
 tasks:
+  default:
+    desc: List available tasks
+    cmds:
+      - task --list
+    silent: true
   lint:
     cmds:
       - npm run lint
+  format:
+    desc: Format source files
+    cmds:
+      - npm run format
   test:
     cmds:
       - npm test

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "actual-intreset",
+  "name": "actual-budget-mortgage",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -15,7 +15,9 @@
         "date-fns": "^4.1.0",
         "dotenv": "^16.5.0",
         "eslint": "^8.50.0",
+        "eslint-config-prettier": "^9.1.0",
         "jest": "^30.0.4",
+        "prettier": "^3.3.1",
         "ts-jest": "^29.4.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
@@ -5590,6 +5592,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/eslint-config-prettier": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
+      "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "scripts": {
     "run": "ts-node actual-mortgage-interest.ts",
     "lint": "eslint --ext .ts . --fix",
+    "format": "prettier --write .",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"
@@ -15,10 +16,12 @@
     "date-fns": "^4.1.0",
     "dotenv": "^16.5.0",
     "eslint": "^8.50.0",
+    "eslint-config-prettier": "^9.1.0",
     "jest": "^30.0.4",
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "prettier": "^3.3.1"
   },
   "compilerOptions": {
     "sourceMap": true,
@@ -38,7 +41,8 @@
     ],
     "extends": [
       "eslint:recommended",
-      "plugin:@typescript-eslint/recommended"
+      "plugin:@typescript-eslint/recommended",
+      "prettier"
     ],
     "rules": {
       "semi": [


### PR DESCRIPTION
## Summary
- use eslint-config-prettier to disable rules conflicting with Prettier
- document the Prettier integration in development section

## Testing
- `npm test` *(fails: Node and npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687759bf1c28832eb9a464085f745ab5