### PR TITLE
Handle config and helper errors with Result type

### DIFF
--- a/result.ts
+++ b/result.ts
@@ -1,0 +1,4 @@
+export interface Result<T> {
+  value?: T;
+  error?: Error;
+}

--- a/test/actual-mortgage-interest.test.ts
+++ b/test/actual-mortgage-interest.test.ts
@@ -253,13 +253,24 @@ describe("Mortgage Interest Calculations", () => {
 
 describe("Configuration Loading", () => {
   it("should load config from environment variables", () => {
-    const config = loadConfig();
+    const result = loadConfig();
+    expect(result.error).toBeUndefined();
+    const config = result.value!;
 
     expect(config.url).toBe("https://actual.spruit.xyz");
     expect(config.annualRate).toBe(0.04);
     expect(config.bookingDay).toBe(1);
     expect(config.mortgageAccount).toBe("Test Mortgage");
     expect(config.interestCategory).toBe("Test Mortgage Interest");
+  });
+
+  it("should return error when required env vars are missing", () => {
+    const original = process.env.ACTUAL_PASSWORD;
+    delete process.env.ACTUAL_PASSWORD;
+    const result = loadConfig();
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toMatch(/ACTUAL_PASSWORD/);
+    process.env.ACTUAL_PASSWORD = original;
   });
 });
 
@@ -295,7 +306,8 @@ describe("MortgageInterestService Integration", () => {
   });
 
   it("should initialize properly", async () => {
-    await service.initialize();
+    const res = await service.initialize();
+    expect(res.error).toBeUndefined();
 
     expect(mockDeps.init).toHaveBeenCalled();
     expect(mockDeps.downloadBudget).toHaveBeenCalled();
@@ -304,7 +316,8 @@ describe("MortgageInterestService Integration", () => {
   });
 
   it("should calculate correct interest with improved method", async () => {
-    await service.initialize();
+    const res = await service.initialize();
+    expect(res.error).toBeUndefined();
 
     const balance = 20000000; // €200,000
     const expectedInterest = calculateMonthlyInterest(balance, 0.034);


### PR DESCRIPTION
## Summary
- add a generic `Result<T>` type
- return `Result<Config>` from `loadConfig`
- refactor helper functions to return `Result` values instead of throwing
- update `MortgageInterestService` to propagate errors using the new pattern
- adjust tests for new return values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878be3dfa9c832eae3ed198dccfd559